### PR TITLE
Endpoint Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ The following settings must be passed as environment variables as shown in the e
 | `AWS_ACCESS_KEY_ID` | Your AWS Access Key. [More info here.](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html) | `secret` | **Yes** | N/A |
 | `AWS_SECRET_ACCESS_KEY` | Your AWS Secret Access Key. [More info here.](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html) | `secret` | **Yes** | N/A |
 | `AWS_S3_BUCKET` | The name of the bucket you're syncing to. For example, `jarv.is`. | `secret` | **Yes** | N/A |
-| `AWS_S3_ENDPOINT` | The endpoint URL of the bucket you're syncing to. Can be used for VPC scenarios or for S3 compliant products like [DigitalOcean Spaces](https://www.digitalocean.com/community/tools/adapting-an-existing-aws-s3-application-to-digitalocean-spaces). | `env` | No | AWS |
 | `AWS_REGION` | The region where you created your bucket in. For example, `us-east-1`. [Full list of regions here.](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) | `env` | **Yes** | N/A |
+| `AWS_S3_ENDPOINT` | The endpoint URL of the bucket you're syncing to. Can be used for VPC scenarios or for S3 compliant products like [DigitalOcean Spaces](https://www.digitalocean.com/community/tools/adapting-an-existing-aws-s3-application-to-digitalocean-spaces). | `env` | No | AWS |
 | `SOURCE_DIR` | The local directory you wish to sync/upload to S3. For example, `./public` | `env` | No | `.` |
 | `DEST_DIR` | The directory inside of the S3 bucket you wish to sync/upload to. Eg: `my_project/assets`.  | `env` | No | `/` |
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The following settings must be passed as environment variables as shown in the e
 | `AWS_ACCESS_KEY_ID` | Your AWS Access Key. [More info here.](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html) | `secret` | **Yes** | N/A |
 | `AWS_SECRET_ACCESS_KEY` | Your AWS Secret Access Key. [More info here.](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html) | `secret` | **Yes** | N/A |
 | `AWS_S3_BUCKET` | The name of the bucket you're syncing to. For example, `jarv.is`. | `secret` | **Yes** | N/A |
+| `AWS_S3_ENDPOINT` | The endpoint URL of the bucket you're syncing to. Can be used for VPC scenarios or for S3 compliant products like [DigitalOcean Spaces](https://www.digitalocean.com/community/tools/adapting-an-existing-aws-s3-application-to-digitalocean-spaces). | `env` | No | AWS |
 | `AWS_REGION` | The region where you created your bucket in. For example, `us-east-1`. [Full list of regions here.](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) | `env` | **Yes** | N/A |
 | `SOURCE_DIR` | The local directory you wish to sync/upload to S3. For example, `./public` | `env` | No | `.` |
 | `DEST_DIR` | The directory inside of the S3 bucket you wish to sync/upload to. Eg: `my_project/assets`.  | `env` | No | `/` |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,9 +22,14 @@ if [ -z "$AWS_REGION" ]; then
   exit 1
 fi
 
+# Default to CLI defined AWS endpoint
+ENDPOINT_APPEND=""
+if [ "$AWS_S3_ENDPOINT" ]; then
+  ENDPOINT_APPEND="--endpoint-url $AWS_S3_ENDPOINT"
+fi
+
 # Default to syncing entire repo if SOURCE_DIR not set.
 SOURCE_DIR=${SOURCE_DIR:-.}
-ENDPOINT_APPEND=${"--endpoint-url $AWS_S3_ENDPOINT":-}
 
 # Create a dedicated profile for this action to avoid
 # conflicts with other actions.
@@ -39,6 +44,5 @@ EOF
 # Use our dedicated profile and suppress verbose messages.
 # All other flags are optional via `args:` directive.
 sh -c "aws s3 sync ${SOURCE_DIR} s3://${AWS_S3_BUCKET}/${DEST_DIR} \
-              --profile s3-sync-action \
-              ${ENDPOINT_APPEND} \
+              --profile s3-sync-action ${ENDPOINT_APPEND} \
               --no-progress $*"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,6 +24,7 @@ fi
 
 # Default to syncing entire repo if SOURCE_DIR not set.
 SOURCE_DIR=${SOURCE_DIR:-.}
+ENDPOINT_APPEND=${"--endpoint-url $AWS_S3_ENDPOINT":-}
 
 # Create a dedicated profile for this action to avoid
 # conflicts with other actions.
@@ -39,4 +40,5 @@ EOF
 # All other flags are optional via `args:` directive.
 sh -c "aws s3 sync ${SOURCE_DIR} s3://${AWS_S3_BUCKET}/${DEST_DIR} \
               --profile s3-sync-action \
+              ${ENDPOINT_APPEND} \
               --no-progress $*"


### PR DESCRIPTION
Added an AWS_S3_ENDPOINT environmental variable that allows this action to upload to interoperable products like DigitalOcean Spaces. The --endpoint-url flag is also used in certain AWS VPC environments. If not present, the script fallbacks to the S3 endpoints defined by the CLI.