### PR TITLE
remove beta notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # GitHub Action to Sync S3 Bucket 🔄
 
-> **⚠️ Note:** To use this action, you must have access to the [GitHub Actions](https://github.com/features/actions) feature. GitHub Actions are currently only available in public beta. You can [apply for the GitHub Actions beta here](https://github.com/features/actions/signup/).
-
 This simple action uses the [vanilla AWS CLI](https://docs.aws.amazon.com/cli/index.html) to sync a directory (either from your repository or generated during your workflow) with a remote S3 bucket.
 
 


### PR DESCRIPTION
Github actions are generally available since today.