### PR TITLE
Add .github_sha file to $SOURCE_DIR

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,9 @@ if [ -n "$AWS_S3_ENDPOINT" ]; then
   ENDPOINT_APPEND="--endpoint-url $AWS_S3_ENDPOINT"
 fi
 
+# Write out GITHUB_SHA to SOURCE_DIR/.github_sha
+echo ${GITHUB_SHA} > "${SOURCE_DIR}/.github_sha"
+
 # Create a dedicated profile for this action to avoid conflicts
 # with past/future actions.
 # https://github.com/jakejarvis/s3-sync-action/issues/1


### PR DESCRIPTION
This allows you to keep track of the current GITHUB_SHA that is deployed
to the S3 bucket.  This is useful to see what version the files are that
are uploaded to your S3 bucket.