### PR TITLE
Added args to inputs and passed to docker

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,15 @@
 name: "S3 Sync"
 description: "Sync a directory to an AWS S3 repository"
 author: jakejarvis
+inputs:
+  args:
+    description: 'Additional arguments for s3 sync'
+    required: false
 runs:
   using: docker
   image: Dockerfile
+  args:
+    - ${{ inputs.args }}
 branding:
   icon: refresh-cw
   color: green


### PR DESCRIPTION
The README shows that args should be included when using the action, and appear to be properly used within the entry point script, but the action.yml file did not allow for the args inputs, or pass them to docker.