### PR TITLE
Update to AWS CLI v2 with prebuilt docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM amazon/aws-cli:2.0.58
 
 LABEL "com.github.actions.name"="S3 Sync"
 LABEL "com.github.actions.description"="Sync a directory to an AWS S3 repository"
@@ -11,9 +11,6 @@ LABEL homepage="https://jarv.is/"
 LABEL maintainer="Jake Jarvis <jake@jarv.is>"
 
 # https://github.com/aws/aws-cli/blob/master/CHANGELOG.rst
-ENV AWSCLI_VERSION='1.18.14'
-
-RUN pip install --quiet --no-cache-dir awscli==${AWSCLI_VERSION}
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazon/aws-cli:2.0.58
+FROM amazon/aws-cli:2.2.9
 
 LABEL "com.github.actions.name"="S3 Sync"
 LABEL "com.github.actions.description"="Sync a directory to an AWS S3 repository"


### PR DESCRIPTION
AWS now has their own Docker [Image](https://hub.docker.com/r/amazon/aws-cli/) of AWS CLI v2 

This pull request tries to update AWS CLI version and replace docker image of python and replace it with AWS provided Docker Image.

Issue: #42 

More info can be found here : https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-docker.html