### PR TITLE
Allow Assume roles using AWS Official Credential Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_ASSUMED_ROLE }}
           
-    - uses: brajm008/s3-sync-action@master
+    - uses: jakejarvis/s3-sync-action@master
       with:
         args: --acl public-read --follow-symlinks --delete
       env:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The following settings must be passed as environment variables as shown in the e
 | `AWS_SECRET_ACCESS_KEY` | Your AWS Secret Access Key. [More info here.](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html) | `secret env` | **Yes** | N/A |
 | `AWS_S3_BUCKET` | The name of the bucket you're syncing to. For example, `jarv.is` or `my-app-releases`. | `secret env` | **Yes** | N/A |
 | `AWS_REGION` | The region where you created your bucket. Set to `us-east-1` by default. [Full list of regions here.](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) | `env` | No | `us-east-1` |
-| `AWS_ASSUMED_ROLE` | The ARN of a role being assumed to deploy to S3 Bucket | `env` | No | N/A |
+| `AWS_ASSUMED_ROLE` | The ARN of a role being assumed to deploy to S3 Bucket | `secret env` | No | N/A |
 | `AWS_S3_ENDPOINT` | The endpoint URL of the bucket you're syncing to. Can be used for [VPC scenarios](https://aws.amazon.com/blogs/aws/new-vpc-endpoint-for-amazon-s3/) or for non-AWS services using the S3 API, like [DigitalOcean Spaces](https://www.digitalocean.com/community/tools/adapting-an-existing-aws-s3-application-to-digitalocean-spaces). | `env` | No | Automatic (`s3.amazonaws.com` or AWS's region-specific equivalent) |
 | `SOURCE_DIR` | The local directory (or file) you wish to sync/upload to S3. For example, `public`. Defaults to your entire repository. | `env` | No | `./` (root of cloned repository) |
 | `DEST_DIR` | The directory inside of the S3 bucket you wish to sync/upload to. For example, `my_project/assets`. Defaults to the root of the bucket. | `env` | No | `/` (root of bucket) |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ The following settings must be passed as environment variables as shown in the e
 
 | Key | Value | Suggested Type | Required | Default |
 | ------------- | ------------- | ------------- | ------------- | ------------- |
-N/A |
 | `AWS_S3_BUCKET` | The name of the bucket you're syncing to. For example, `jarv.is` or `my-app-releases`. | `secret env` | **Yes** | N/A |
 | `AWS_REGION` | The region where you created your bucket. Set to `us-east-1` by default. [Full list of regions here.](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) | `env` | No | `us-east-1` |
 | `AWS_S3_ENDPOINT` | The endpoint URL of the bucket you're syncing to. Can be used for [VPC scenarios](https://aws.amazon.com/blogs/aws/new-vpc-endpoint-for-amazon-s3/) or for non-AWS services using the S3 API, like [DigitalOcean Spaces](https://www.digitalocean.com/community/tools/adapting-an-existing-aws-s3-application-to-digitalocean-spaces). | `env` | No | Automatic (`s3.amazonaws.com` or AWS's region-specific equivalent) |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The following settings must be passed as environment variables as shown in the e
 | `AWS_SECRET_ACCESS_KEY` | Your AWS Secret Access Key. [More info here.](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html) | `secret env` | **Yes** | N/A |
 | `AWS_S3_BUCKET` | The name of the bucket you're syncing to. For example, `jarv.is` or `my-app-releases`. | `secret env` | **Yes** | N/A |
 | `AWS_REGION` | The region where you created your bucket. Set to `us-east-1` by default. [Full list of regions here.](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) | `env` | No | `us-east-1` |
-| `AWS_ASSUMED_ROLE` | The ARN of a role being assumed to deploy to S3 Bucket | `env` | No | null |
+| `AWS_ASSUMED_ROLE` | The ARN of a role being assumed to deploy to S3 Bucket | `env` | No | N/A |
 | `AWS_S3_ENDPOINT` | The endpoint URL of the bucket you're syncing to. Can be used for [VPC scenarios](https://aws.amazon.com/blogs/aws/new-vpc-endpoint-for-amazon-s3/) or for non-AWS services using the S3 API, like [DigitalOcean Spaces](https://www.digitalocean.com/community/tools/adapting-an-existing-aws-s3-application-to-digitalocean-spaces). | `env` | No | Automatic (`s3.amazonaws.com` or AWS's region-specific equivalent) |
 | `SOURCE_DIR` | The local directory (or file) you wish to sync/upload to S3. For example, `public`. Defaults to your entire repository. | `env` | No | `./` (root of cloned repository) |
 | `DEST_DIR` | The directory inside of the S3 bucket you wish to sync/upload to. For example, `my_project/assets`. Defaults to the root of the bucket. | `env` | No | `/` (root of bucket) |

--- a/README.md
+++ b/README.md
@@ -31,15 +31,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: jakejarvis/s3-sync-action@master
+    
+    - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ASSUMED_ROLE }}
+          
+    - uses: brajm008/s3-sync-action@master
       with:
         args: --acl public-read --follow-symlinks --delete
       env:
         AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_REGION: 'us-west-1'                           # optional: defaults to us-east-1
-        AWS_ASSUMED_ROLE: ${{ secrets.AWS_ASSUMED_ROLE }} # optional: defaults to not assumed role
+        AWS_REGION: ${{ secrets.AWS_REGION }}             # optional: defaults to us-east-1
         SOURCE_DIR: 'public'                              # optional: defaults to entire repository
 ```
 
@@ -50,11 +56,9 @@ The following settings must be passed as environment variables as shown in the e
 
 | Key | Value | Suggested Type | Required | Default |
 | ------------- | ------------- | ------------- | ------------- | ------------- |
-| `AWS_ACCESS_KEY_ID` | Your AWS Access Key. [More info here.](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html) | `secret env` | **Yes** | N/A |
-| `AWS_SECRET_ACCESS_KEY` | Your AWS Secret Access Key. [More info here.](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html) | `secret env` | **Yes** | N/A |
+N/A |
 | `AWS_S3_BUCKET` | The name of the bucket you're syncing to. For example, `jarv.is` or `my-app-releases`. | `secret env` | **Yes** | N/A |
 | `AWS_REGION` | The region where you created your bucket. Set to `us-east-1` by default. [Full list of regions here.](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) | `env` | No | `us-east-1` |
-| `AWS_ASSUMED_ROLE` | The ARN of a role being assumed to deploy to S3 Bucket | `secret env` | No | N/A |
 | `AWS_S3_ENDPOINT` | The endpoint URL of the bucket you're syncing to. Can be used for [VPC scenarios](https://aws.amazon.com/blogs/aws/new-vpc-endpoint-for-amazon-s3/) or for non-AWS services using the S3 API, like [DigitalOcean Spaces](https://www.digitalocean.com/community/tools/adapting-an-existing-aws-s3-application-to-digitalocean-spaces). | `env` | No | Automatic (`s3.amazonaws.com` or AWS's region-specific equivalent) |
 | `SOURCE_DIR` | The local directory (or file) you wish to sync/upload to S3. For example, `public`. Defaults to your entire repository. | `env` | No | `./` (root of cloned repository) |
 | `DEST_DIR` | The directory inside of the S3 bucket you wish to sync/upload to. For example, `my_project/assets`. Defaults to the root of the bucket. | `env` | No | `/` (root of bucket) |

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ jobs:
         AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_REGION: 'us-west-1'   # optional: defaults to us-east-1
-        SOURCE_DIR: 'public'      # optional: defaults to entire repository
+        AWS_REGION: 'us-west-1'                           # optional: defaults to us-east-1
+        AWS_ASSUMED_ROLE: ${{ secrets.AWS_ASSUMED_ROLE }} # optional: defaults to not assumed role
+        SOURCE_DIR: 'public'                              # optional: defaults to entire repository
 ```
 
 
@@ -53,6 +54,7 @@ The following settings must be passed as environment variables as shown in the e
 | `AWS_SECRET_ACCESS_KEY` | Your AWS Secret Access Key. [More info here.](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html) | `secret env` | **Yes** | N/A |
 | `AWS_S3_BUCKET` | The name of the bucket you're syncing to. For example, `jarv.is` or `my-app-releases`. | `secret env` | **Yes** | N/A |
 | `AWS_REGION` | The region where you created your bucket. Set to `us-east-1` by default. [Full list of regions here.](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) | `env` | No | `us-east-1` |
+| `AWS_ASSUMED_ROLE` | The ARN of a role being assumed to deploy to S3 Bucket | `env` | No | null |
 | `AWS_S3_ENDPOINT` | The endpoint URL of the bucket you're syncing to. Can be used for [VPC scenarios](https://aws.amazon.com/blogs/aws/new-vpc-endpoint-for-amazon-s3/) or for non-AWS services using the S3 API, like [DigitalOcean Spaces](https://www.digitalocean.com/community/tools/adapting-an-existing-aws-s3-application-to-digitalocean-spaces). | `env` | No | Automatic (`s3.amazonaws.com` or AWS's region-specific equivalent) |
 | `SOURCE_DIR` | The local directory (or file) you wish to sync/upload to S3. For example, `public`. Defaults to your entire repository. | `env` | No | `./` (root of cloned repository) |
 | `DEST_DIR` | The directory inside of the S3 bucket you wish to sync/upload to. For example, `my_project/assets`. Defaults to the root of the bucket. | `env` | No | `/` (root of bucket) |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,16 +7,6 @@ if [ -z "$AWS_S3_BUCKET" ]; then
   exit 1
 fi
 
-# if [ -z "$AWS_ACCESS_KEY_ID" ]; then
-#   echo "AWS_ACCESS_KEY_ID is not set. Quitting."
-#   exit 1
-# fi
-
-# if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-#   echo "AWS_SECRET_ACCESS_KEY is not set. Quitting."
-#   exit 1
-# fi
-
 # Default to us-east-1 if AWS_REGION not set.
 if [ -z "$AWS_REGION" ]; then
   AWS_REGION="us-east-1"
@@ -26,13 +16,6 @@ fi
 if [ -n "$AWS_S3_ENDPOINT" ]; then
   ENDPOINT_APPEND="--endpoint-url $AWS_S3_ENDPOINT"
 fi
-
-# aws configure --profile s3-sync-action <<-EOF > /dev/null 2>&1
-# ${AWS_ACCESS_KEY_ID}
-# ${AWS_SECRET_ACCESS_KEY}
-# ${AWS_REGION}
-# text
-# EOF
 
 # Sync using our dedicated profile and suppress verbose messages.
 # All other flags are optional via the `args:` directive.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+apt-get install jq
+
 SaveCredentials() {
   [[ -d ~/.assumerole.d/cache ]] || mkdir -p ~/.assumerole.d/cache
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,15 +27,6 @@ if [ -n "$AWS_S3_ENDPOINT" ]; then
   ENDPOINT_APPEND="--endpoint-url $AWS_S3_ENDPOINT"
 fi
 
-# Assume Role if user sets AWS_ASSUMED_ROLE.
-if [ -n "$AWS_ASSUMED_ROLE" ]; then
-  aws iam list-roles --query "Roles[?RoleName == '$AWS_ASSUMED_ROLE'].[RoleName, Arn]"
-  aws sts assume-role --role-arn "$AWS_ASSUMED_ROLE" --role-session-name "S3 Update CI"
-  export AWS_ACCESS_KEY_ID=RoleAccessKeyID
-  export AWS_SECRET_ACCESS_KEY=RoleSecretKey
-  export AWS_SESSION_TOKEN=RoleSessionToken
-fi
-
 # Create a dedicated profile for this action to avoid conflicts
 # with past/future actions.
 # https://github.com/jakejarvis/s3-sync-action/issues/1
@@ -45,6 +36,15 @@ ${AWS_SECRET_ACCESS_KEY}
 ${AWS_REGION}
 text
 EOF
+
+# Assume Role if user sets AWS_ASSUMED_ROLE.
+if [ -n "$AWS_ASSUMED_ROLE" ]; then
+  aws iam list-roles --query "Roles[?RoleName == '$AWS_ASSUMED_ROLE'].[RoleName, Arn]"
+  aws sts assume-role --role-arn "$AWS_ASSUMED_ROLE" --role-session-name "S3 Update CI"
+  export AWS_ACCESS_KEY_ID=RoleAccessKeyID
+  export AWS_SECRET_ACCESS_KEY=RoleSecretKey
+  export AWS_SESSION_TOKEN=RoleSessionToken
+fi
 
 # Sync using our dedicated profile and suppress verbose messages.
 # All other flags are optional via the `args:` directive.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,11 @@ fi
 
 # Assume Role if user sets AWS_ASSUMED_ROLE.
 if [ -n "$AWS_ASSUMED_ROLE" ]; then
+  aws iam list-roles --query "Roles[?RoleName == '$AWS_ASSUMED_ROLE'].[RoleName, Arn]"
   aws sts assume-role --role-arn "$AWS_ASSUMED_ROLE" --role-session-name "S3 Update CI"
+  export AWS_ACCESS_KEY_ID=RoleAccessKeyID
+  export AWS_SECRET_ACCESS_KEY=RoleSecretKey
+  export AWS_SESSION_TOKEN=RoleSessionToken
 fi
 
 # Create a dedicated profile for this action to avoid conflicts

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,9 +27,6 @@ if [ -n "$AWS_S3_ENDPOINT" ]; then
   ENDPOINT_APPEND="--endpoint-url $AWS_S3_ENDPOINT"
 fi
 
-# Create a dedicated profile for this action to avoid conflicts
-# with past/future actions.
-# https://github.com/jakejarvis/s3-sync-action/issues/1
 # aws configure --profile s3-sync-action <<-EOF > /dev/null 2>&1
 # ${AWS_ACCESS_KEY_ID}
 # ${AWS_SECRET_ACCESS_KEY}
@@ -37,48 +34,8 @@ fi
 # text
 # EOF
 
-# Assume Role if user sets AWS_ASSUMED_ROLE.
-# if [ -n "$AWS_ASSUMED_ROLE" ]; then
-#   role_arn="$AWS_ASSUMED_ROLE"
-  
-#   export AWS_PROFILE=${PROFILE}
-  
-#   JSON=$(aws sts assume-role \
-#           --role-arn "$AWS_ASSUMED_ROLE" \
-#           --role-session-name "S3 Update CI" \
-#           --duration-seconds 600
-#           2>/dev/null) || { echo "Error assuming role"; exit 1; }
-#   echo ${JSON}
-#   AWS_ACCESS_KEY_ID=$(echo ${JSON} | jq --raw-output ".Credentials[\"AccessKeyId\"]")
-#   AWS_SECRET_ACCESS_KEY=$(echo ${JSON} | jq --raw-output ".Credentials[\"SecretAccessKey\"]")
-#   AWS_SESSION_TOKEN=$(echo ${JSON} | jq --raw-output ".Credentials[\"SessionToken\"]")
-#   AWS_EXPIRATION=$(echo ${JSON} | jq --raw-output ".Credentials[\"Expiration\"]")
-  
-#   unset AWS_PROFILE
-  
-#   export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-#   export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-#   export AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
-#   export AWS_ACCOUNT=${aws_account}
-#   export AWS_ACCOUNT_ID=${ACCOUNT}
-  
-#   # SaveCredentials
-# fi
-
 # Sync using our dedicated profile and suppress verbose messages.
 # All other flags are optional via the `args:` directive.
 sh -c "aws s3 sync ${SOURCE_DIR:-.} s3://${AWS_S3_BUCKET}/${DEST_DIR} \
-              --profile s3-sync-action \
               --no-progress \
               ${ENDPOINT_APPEND} $*"
-
-# Clear out credentials after we're done.
-# We need to re-run `aws configure` with bogus input instead of
-# deleting ~/.aws in case there are other credentials living there.
-# https://forums.aws.amazon.com/thread.jspa?threadID=148833
-aws configure --profile s3-sync-action <<-EOF > /dev/null 2>&1
-null
-null
-null
-text
-EOF

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,25 +1,5 @@
 #!/bin/sh
 
-sudo apt-get install jq
-
-SaveCredentials() {
-  [[ -d ~/.assumerole.d/cache ]] || mkdir -p ~/.assumerole.d/cache
-
-  echo "export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" > ~/.assumerole.d/cache/${aws_account}
-  echo "export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> ~/.assumerole.d/cache/${aws_account}
-  echo "export AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}" >> ~/.assumerole.d/cache/${aws_account}
-  echo "export ROLE=${ROLE}" >> ~/.assumerole.d/cache/${aws_account}
-  echo "export ACCOUNT=${ACCOUNT}" >> ~/.assumerole.d/cache/${aws_account}
-  echo "export AWS_ACCOUNT_ID=${ACCOUNT}" >> ~/.assumerole.d/cache/${aws_account}
-  echo "export aws_account=${aws_account}" >> ~/.assumerole.d/cache/${aws_account}
-  echo "export AWS_ACCOUNT=${aws_account}" >> ~/.assumerole.d/cache/${aws_account}
-  echo "export AWS_EXPIRATION=${AWS_EXPIRATION}" >> ~/.assumerole.d/cache/${aws_account}
-  echo "export SSHKEY=${SSHKEY}" >> ~/.assumerole.d/cache/${aws_account}
-  echo ${ASSUMEROLE_ENV} >> ~/.assumerole.d/cache/${aws_account}
-
-  chmod 0600 ~/.assumerole.d/cache/${aws_account}
-}
-
 set -e
 
 if [ -z "$AWS_S3_BUCKET" ]; then
@@ -68,7 +48,7 @@ if [ -n "$AWS_ASSUMED_ROLE" ]; then
           --role-session-name "S3 Update CI" \
           --duration-seconds 600
           2>/dev/null) || { echo "Error assuming role"; exit 1; }
-  
+  echo ${JSON}
   AWS_ACCESS_KEY_ID=$(echo ${JSON} | jq --raw-output ".Credentials[\"AccessKeyId\"]")
   AWS_SECRET_ACCESS_KEY=$(echo ${JSON} | jq --raw-output ".Credentials[\"SecretAccessKey\"]")
   AWS_SESSION_TOKEN=$(echo ${JSON} | jq --raw-output ".Credentials[\"SessionToken\"]")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,12 +66,6 @@ if [ -n "$AWS_ASSUMED_ROLE" ]; then
           --role-session-name "S3 Update CI" \
           --duration-seconds 600
           2>/dev/null) || { echo "Error assuming role"; exit 1; }
-          
-  AWS_ACCESS_KEY_ID=$(echo ${JSON} | jq --raw-output ".Credentials[\"AccessKeyId\"]")
-  AWS_SECRET_ACCESS_KEY=$(echo ${JSON} | jq --raw-output ".Credentials[\"SecretAccessKey\"]")
-  AWS_SESSION_TOKEN=$(echo ${JSON} | jq --raw-output ".Credentials[\"SessionToken\"]")
-  AWS_EXPIRATION=$(echo ${JSON} | jq --raw-output ".Credentials[\"Expiration\"]")
-  
   unset AWS_PROFILE
   
   export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,11 @@ if [ -n "$AWS_S3_ENDPOINT" ]; then
   ENDPOINT_APPEND="--endpoint-url $AWS_S3_ENDPOINT"
 fi
 
+# Assume Role if user sets AWS_ASSUMED_ROLE.
+if [ -n "$AWS_ASSUMED_ROLE" ]; then
+  aws sts assume-role --role-arn "$AWS_ASSUMED_ROLE" --role-session-name "S3 Update CI"
+fi
+
 # Create a dedicated profile for this action to avoid conflicts
 # with past/future actions.
 # https://github.com/jakejarvis/s3-sync-action/issues/1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-sudo apt-get install jq
-
 set -e
 
 if [ -z "$AWS_S3_BUCKET" ]; then
@@ -32,40 +30,40 @@ fi
 # Create a dedicated profile for this action to avoid conflicts
 # with past/future actions.
 # https://github.com/jakejarvis/s3-sync-action/issues/1
-aws configure --profile s3-sync-action <<-EOF > /dev/null 2>&1
-${AWS_ACCESS_KEY_ID}
-${AWS_SECRET_ACCESS_KEY}
-${AWS_REGION}
-text
-EOF
+# aws configure --profile s3-sync-action <<-EOF > /dev/null 2>&1
+# ${AWS_ACCESS_KEY_ID}
+# ${AWS_SECRET_ACCESS_KEY}
+# ${AWS_REGION}
+# text
+# EOF
 
 # Assume Role if user sets AWS_ASSUMED_ROLE.
-if [ -n "$AWS_ASSUMED_ROLE" ]; then
-  role_arn="$AWS_ASSUMED_ROLE"
+# if [ -n "$AWS_ASSUMED_ROLE" ]; then
+#   role_arn="$AWS_ASSUMED_ROLE"
   
-  export AWS_PROFILE=${PROFILE}
+#   export AWS_PROFILE=${PROFILE}
   
-  JSON=$(aws sts assume-role \
-          --role-arn "$AWS_ASSUMED_ROLE" \
-          --role-session-name "S3 Update CI" \
-          --duration-seconds 600
-          2>/dev/null) || { echo "Error assuming role"; exit 1; }
-  echo ${JSON}
-  AWS_ACCESS_KEY_ID=$(echo ${JSON} | jq --raw-output ".Credentials[\"AccessKeyId\"]")
-  AWS_SECRET_ACCESS_KEY=$(echo ${JSON} | jq --raw-output ".Credentials[\"SecretAccessKey\"]")
-  AWS_SESSION_TOKEN=$(echo ${JSON} | jq --raw-output ".Credentials[\"SessionToken\"]")
-  AWS_EXPIRATION=$(echo ${JSON} | jq --raw-output ".Credentials[\"Expiration\"]")
+#   JSON=$(aws sts assume-role \
+#           --role-arn "$AWS_ASSUMED_ROLE" \
+#           --role-session-name "S3 Update CI" \
+#           --duration-seconds 600
+#           2>/dev/null) || { echo "Error assuming role"; exit 1; }
+#   echo ${JSON}
+#   AWS_ACCESS_KEY_ID=$(echo ${JSON} | jq --raw-output ".Credentials[\"AccessKeyId\"]")
+#   AWS_SECRET_ACCESS_KEY=$(echo ${JSON} | jq --raw-output ".Credentials[\"SecretAccessKey\"]")
+#   AWS_SESSION_TOKEN=$(echo ${JSON} | jq --raw-output ".Credentials[\"SessionToken\"]")
+#   AWS_EXPIRATION=$(echo ${JSON} | jq --raw-output ".Credentials[\"Expiration\"]")
   
-  unset AWS_PROFILE
+#   unset AWS_PROFILE
   
-  export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-  export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-  export AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
-  export AWS_ACCOUNT=${aws_account}
-  export AWS_ACCOUNT_ID=${ACCOUNT}
+#   export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+#   export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+#   export AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
+#   export AWS_ACCOUNT=${aws_account}
+#   export AWS_ACCOUNT_ID=${ACCOUNT}
   
-  # SaveCredentials
-fi
+#   # SaveCredentials
+# fi
 
 # Sync using our dedicated profile and suppress verbose messages.
 # All other flags are optional via the `args:` directive.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,12 +39,13 @@ EOF
 
 # Assume Role if user sets AWS_ASSUMED_ROLE.
 if [ -n "$AWS_ASSUMED_ROLE" ]; then
-  aws sts get-caller-identity
-  aws iam list-roles --query "Roles[?RoleName == '$AWS_ASSUMED_ROLE'].[RoleName, Arn]"
-  aws sts assume-role --role-arn "$AWS_ASSUMED_ROLE" --role-session-name "S3 Update CI"
-  export AWS_ACCESS_KEY_ID=RoleAccessKeyID
-  export AWS_SECRET_ACCESS_KEY=RoleSecretKey
-  export AWS_SESSION_TOKEN=RoleSessionToken
+  role_arn="$AWS_ASSUMED_ROLE"
+#   aws sts get-caller-identity
+#   aws iam list-roles --query "Roles[?RoleName == '$AWS_ASSUMED_ROLE'].[RoleName, Arn]"
+#   aws sts assume-role --role-arn "$AWS_ASSUMED_ROLE" --role-session-name "S3 Update CI"
+#   export AWS_ACCESS_KEY_ID=RoleAccessKeyID
+#   export AWS_SECRET_ACCESS_KEY=RoleSecretKey
+#   export AWS_SESSION_TOKEN=RoleSessionToken
 fi
 
 # Sync using our dedicated profile and suppress verbose messages.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,6 +39,7 @@ EOF
 
 # Assume Role if user sets AWS_ASSUMED_ROLE.
 if [ -n "$AWS_ASSUMED_ROLE" ]; then
+  aws sts get-caller-identity
   aws iam list-roles --query "Roles[?RoleName == '$AWS_ASSUMED_ROLE'].[RoleName, Arn]"
   aws sts assume-role --role-arn "$AWS_ASSUMED_ROLE" --role-session-name "S3 Update CI"
   export AWS_ACCESS_KEY_ID=RoleAccessKeyID

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+sudo apt-get install jq
+
 set -e
 
 if [ -z "$AWS_S3_BUCKET" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-apt-get install jq
+sudo apt-get install jq
 
 SaveCredentials() {
   [[ -d ~/.assumerole.d/cache ]] || mkdir -p ~/.assumerole.d/cache

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,15 +7,15 @@ if [ -z "$AWS_S3_BUCKET" ]; then
   exit 1
 fi
 
-if [ -z "$AWS_ACCESS_KEY_ID" ]; then
-  echo "AWS_ACCESS_KEY_ID is not set. Quitting."
-  exit 1
-fi
+# if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+#   echo "AWS_ACCESS_KEY_ID is not set. Quitting."
+#   exit 1
+# fi
 
-if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-  echo "AWS_SECRET_ACCESS_KEY is not set. Quitting."
-  exit 1
-fi
+# if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+#   echo "AWS_SECRET_ACCESS_KEY is not set. Quitting."
+#   exit 1
+# fi
 
 # Default to us-east-1 if AWS_REGION not set.
 if [ -z "$AWS_REGION" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,6 +66,12 @@ if [ -n "$AWS_ASSUMED_ROLE" ]; then
           --role-session-name "S3 Update CI" \
           --duration-seconds 600
           2>/dev/null) || { echo "Error assuming role"; exit 1; }
+  
+  AWS_ACCESS_KEY_ID=$(echo ${JSON} | jq --raw-output ".Credentials[\"AccessKeyId\"]")
+  AWS_SECRET_ACCESS_KEY=$(echo ${JSON} | jq --raw-output ".Credentials[\"SecretAccessKey\"]")
+  AWS_SESSION_TOKEN=$(echo ${JSON} | jq --raw-output ".Credentials[\"SessionToken\"]")
+  AWS_EXPIRATION=$(echo ${JSON} | jq --raw-output ".Credentials[\"Expiration\"]")
+  
   unset AWS_PROFILE
   
   export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
@@ -74,7 +80,7 @@ if [ -n "$AWS_ASSUMED_ROLE" ]; then
   export AWS_ACCOUNT=${aws_account}
   export AWS_ACCOUNT_ID=${ACCOUNT}
   
-  SaveCredentials
+  # SaveCredentials
 fi
 
 # Sync using our dedicated profile and suppress verbose messages.


### PR DESCRIPTION
This adds support to assume a certain role prior to syncing the S3 bucket. 
By using AWS's official Credentials it should reduce complexity and increase maintainability.