### PR TITLE
Add sync downstream option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ The following settings must be passed as environment variables as shown in the e
 | `AWS_S3_BUCKET` | The name of the bucket you're syncing to. For example, `jarv.is` or `my-app-releases`. | `secret env` | **Yes** | N/A |
 | `AWS_REGION` | The region where you created your bucket. Set to `us-east-1` by default. [Full list of regions here.](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) | `env` | No | `us-east-1` |
 | `AWS_S3_ENDPOINT` | The endpoint URL of the bucket you're syncing to. Can be used for [VPC scenarios](https://aws.amazon.com/blogs/aws/new-vpc-endpoint-for-amazon-s3/) or for non-AWS services using the S3 API, like [DigitalOcean Spaces](https://www.digitalocean.com/community/tools/adapting-an-existing-aws-s3-application-to-digitalocean-spaces). | `env` | No | Automatic (`s3.amazonaws.com` or AWS's region-specific equivalent) |
-| `SOURCE_DIR` | The local directory (or file) you wish to sync/upload to S3. For example, `public`. Defaults to your entire repository. | `env` | No | `./` (root of cloned repository) |
-| `DEST_DIR` | The directory inside of the S3 bucket you wish to sync/upload to. For example, `my_project/assets`. Defaults to the root of the bucket. | `env` | No | `/` (root of bucket) |
+| `AWS_DOWNSTREAM` | Use your remote AWS directory to synchronize downstream (download) with your local directory. Set to `false` by default. | `env` | No | `us-east-1` |
+| `SOURCE_DIR` | The local directory (or file) you wish to sync with S3. For example, `public`. Defaults to your entire repository. | `env` | No | `./` (root of cloned repository) |
+| `DEST_DIR` | The directory inside of the S3 bucket you wish to sync with. For example, `my_project/assets`. Defaults to the root of the bucket. | `env` | No | `/` (root of bucket) |
 
 
 ## License

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,16 @@ if [ -n "$AWS_S3_ENDPOINT" ]; then
   ENDPOINT_APPEND="--endpoint-url $AWS_S3_ENDPOINT"
 fi
 
+# Use the AWS directory as source to sync downstream.
+# Default to false if AWS_DOWNSTREAM not set.
+if [ "$AWS_DOWNSTREAM" = true ]; then
+  SOURCE_PATH="s3://${AWS_S3_BUCKET}/${DEST_DIR}" # AWS S3 directory as source
+  DEST_PATH="${SOURCE_DIR:-.}" # Local directory as destination
+else 
+  SOURCE_PATH="${SOURCE_DIR:-.}" # Local directory as source
+  DEST_PATH="s3://${AWS_S3_BUCKET}/${DEST_DIR}" # AWS S3 directory as destination
+fi
+
 # Create a dedicated profile for this action to avoid conflicts
 # with past/future actions.
 # https://github.com/jakejarvis/s3-sync-action/issues/1
@@ -39,7 +49,7 @@ EOF
 
 # Sync using our dedicated profile and suppress verbose messages.
 # All other flags are optional via the `args:` directive.
-sh -c "aws s3 sync ${SOURCE_DIR:-.} s3://${AWS_S3_BUCKET}/${DEST_DIR} \
+sh -c "aws s3 sync ${SOURCE_PATH} ${DEST_PATH} \
               --profile s3-sync-action \
               --no-progress \
               ${ENDPOINT_APPEND} $*"


### PR DESCRIPTION
I came across a special case that required me to sync "downstream" from my ASW S3 directory to my local repository (instead of the sync/upload scenario). 

I didn't want to break the way it works so I added a new "__AWS_DOWNSTREAM__" environment variable. If it's set and _true_ then the SOURCE_DIR is reversed with the DEST_DIR. In this case the DEST_DIR is used as source (AWS S3 directory) and the action will sync/download the contents of the AWS S3 directory to specified local directory. 

Let me know if you would find this change/addition useful 🙂. 