### PR TITLE
Add Linux-only note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Action to Sync S3 Bucket 🔄
 
-This simple action uses the [vanilla AWS CLI](https://docs.aws.amazon.com/cli/index.html) to sync a directory (either from your repository or generated during your workflow) with a remote S3 bucket.
+This simple action uses the [vanilla AWS CLI](https://docs.aws.amazon.com/cli/index.html) to sync a directory (either from your repository or generated during your workflow) with a remote S3 bucket on Linux-run workflows.
 
 
 ## Usage


### PR DESCRIPTION
Ran into this while experimenting with an Action that required Windows and thought a reference to the OS requirement might help future folks.

<img width="282" alt="Workflow run log with an error from s3-sync-action saying container action is only supported on Linux." src="https://github.com/jakejarvis/s3-sync-action/assets/713665/70ef2605-d0ab-477d-8952-d827045efb37">

Not a fix, but could be helpful for folks unknowingly impacted by #21 and #54.