### PR TITLE
AWS OIDC Compatibility

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,6 +33,7 @@ fi
 aws configure --profile s3-sync-action <<-EOF > /dev/null 2>&1
 ${AWS_ACCESS_KEY_ID}
 ${AWS_SECRET_ACCESS_KEY}
+${AWS_SESSION_TOKEN}
 ${AWS_REGION}
 text
 EOF
@@ -49,6 +50,7 @@ sh -c "aws s3 sync ${SOURCE_DIR:-.} s3://${AWS_S3_BUCKET}/${DEST_DIR} \
 # deleting ~/.aws in case there are other credentials living there.
 # https://forums.aws.amazon.com/thread.jspa?threadID=148833
 aws configure --profile s3-sync-action <<-EOF > /dev/null 2>&1
+null
 null
 null
 null

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,21 +27,23 @@ if [ -n "$AWS_S3_ENDPOINT" ]; then
   ENDPOINT_APPEND="--endpoint-url $AWS_S3_ENDPOINT"
 fi
 
-# Create a dedicated profile for this action to avoid conflicts
-# with past/future actions.
-# https://github.com/jakejarvis/s3-sync-action/issues/1
-aws configure --profile s3-sync-action <<-EOF > /dev/null 2>&1
-${AWS_ACCESS_KEY_ID}
-${AWS_SECRET_ACCESS_KEY}
-${AWS_SESSION_TOKEN}
-${AWS_REGION}
-text
+if [[ -z "$AWS_SESSION_TOKEN" ]]; then
+  # AWS_SESSION_TOKEN will be set when using OIDC creds
+  # Create a dedicated profile for this action to avoid
+  # conflicts with other actions.
+  # https://github.com/jakejarvis/s3-sync-action/issues/1
+  _aws_profile="--profile s3-sync-action"
+  aws configure $_aws_profile <<-EOF > /dev/null 2>&1
+  ${AWS_ACCESS_KEY_ID}
+  ${AWS_SECRET_ACCESS_KEY}
+  ${AWS_REGION}
+  text
 EOF
+fi
 
 # Sync using our dedicated profile and suppress verbose messages.
 # All other flags are optional via the `args:` directive.
-sh -c "aws s3 sync ${SOURCE_DIR:-.} s3://${AWS_S3_BUCKET}/${DEST_DIR} \
-              --profile s3-sync-action \
+sh -c "aws $_aws_profile s3 sync ${SOURCE_DIR:-.} s3://${AWS_S3_BUCKET}/${DEST_DIR} \
               --no-progress \
               ${ENDPOINT_APPEND} $*"
 
@@ -50,7 +52,6 @@ sh -c "aws s3 sync ${SOURCE_DIR:-.} s3://${AWS_S3_BUCKET}/${DEST_DIR} \
 # deleting ~/.aws in case there are other credentials living there.
 # https://forums.aws.amazon.com/thread.jspa?threadID=148833
 aws configure --profile s3-sync-action <<-EOF > /dev/null 2>&1
-null
 null
 null
 null


### PR DESCRIPTION
When using _configure-aws-credentials_ instead of an access key / secret combination, this action fails with the following error:

> fatal error: An error occurred (InvalidAccessKeyId) when calling the ListObjectsV2 operation: The AWS Access Key Id you provided does not exist in our records.

The fix is to check if a session token is present (since it is created through the _configure-aws-credentials_ action). This allows the action to be used with both the access key / secret combination as it was before and adds compatibility with AWS OIDC.